### PR TITLE
fix: Nth-weekday-of-month Compliance deadlines for ordinal-week rules

### DIFF
--- a/ServiceBackendConfigurationPlugin/Core.cs
+++ b/ServiceBackendConfigurationPlugin/Core.cs
@@ -41,6 +41,7 @@ namespace ServiceBackendConfigurationPlugin;
 
 using Castle.MicroKernel.Registration;
 using Castle.Windsor;
+using Infrastructure;
 using Infrastructure.Helpers;
 using Installers;
 using Messages;
@@ -404,11 +405,18 @@ public class Core : ISdkEventHandler
 
                     try
                     {
+                        var deadline = (DateTime) planning.NextExecutionTime!;
+                        if (areaRulePlanning.RepeatOrdinalWeek is > 0)
+                        {
+                            var snapped = RecurrenceHelper.NthWeekdayOfMonth(
+                                deadline.Year, deadline.Month, areaRulePlanning.RepeatOrdinalWeek.Value, areaRulePlanning.DayOfWeek);
+                            if (snapped != null) deadline = snapped.Value;
+                        }
                         var compliance = new Compliance
                         {
                             PlanningId = planning.Id,
                             AreaId = areaRulePlanning.AreaId,
-                            Deadline = (DateTime) planning.NextExecutionTime!,
+                            Deadline = new DateTime(deadline.Year, deadline.Month, deadline.Day, 0, 0, 0),
                             StartDate = (DateTime) planning.LastExecutedTime!,
                             MicrotingSdkCaseId = planningCase.MicrotingSdkCaseId,
                             MicrotingSdkeFormId = planning.RelatedEFormId,

--- a/ServiceBackendConfigurationPlugin/Handlers/EformParsedByServerHandler.cs
+++ b/ServiceBackendConfigurationPlugin/Handlers/EformParsedByServerHandler.cs
@@ -33,6 +33,7 @@ using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
 using Microting.ItemsPlanningBase.Infrastructure.Data;
 using Microting.ItemsPlanningBase.Infrastructure.Enums;
 using Rebus.Handlers;
+using ServiceBackendConfigurationPlugin.Infrastructure;
 using ServiceBackendConfigurationPlugin.Infrastructure.Helpers;
 using ServiceBackendConfigurationPlugin.Messages;
 
@@ -140,7 +141,17 @@ public class EformParsedByServerHandler(
 
                     if (planning.RepeatType == RepeatType.Month)
                     {
-                        if (planning.DayOfMonth != null)
+                        if (areaRulePlanning.RepeatOrdinalWeek is > 0)
+                        {
+                            var target = new DateTime(now.Year, now.Month, 1, 0, 0, 0).AddMonths(planning.RepeatEvery);
+                            var snapped = RecurrenceHelper.NthWeekdayOfMonth(
+                                target.Year, target.Month, areaRulePlanning.RepeatOrdinalWeek.Value, areaRulePlanning.DayOfWeek)
+                                ?? RecurrenceHelper.NthWeekdayOfMonth(target.Year, target.Month, 4, areaRulePlanning.DayOfWeek)
+                                ?? RecurrenceHelper.NthWeekdayOfMonth(target.Year, target.Month, 3, areaRulePlanning.DayOfWeek);
+                            planning.NextExecutionTime = new DateTime(snapped!.Value.Year, snapped.Value.Month, snapped.Value.Day, 0, 0, 0);
+                            await planning.Update(itemsPlanningPnDbContext);
+                        }
+                        else if (planning.DayOfMonth != null)
                         {
                             if (planning.DayOfMonth == 0)
                             {
@@ -165,6 +176,15 @@ public class EformParsedByServerHandler(
                 {
                     Console.WriteLine($"info: We did not find a compliance for {planningCaseSite.PlanningId}, so we create one");
                     var deadLine = (DateTime)planning.NextExecutionTime!;
+                    if (areaRulePlanning.RepeatOrdinalWeek is > 0)
+                    {
+                        var snappedDeadLine = RecurrenceHelper.NthWeekdayOfMonth(
+                            deadLine.Year, deadLine.Month, areaRulePlanning.RepeatOrdinalWeek.Value, areaRulePlanning.DayOfWeek);
+                        if (snappedDeadLine != null)
+                        {
+                            deadLine = snappedDeadLine.Value;
+                        }
+                    }
                     try
                     {
                         var compliance = new Compliance

--- a/ServiceBackendConfigurationPlugin/Handlers/eFormCompletedHandler.cs
+++ b/ServiceBackendConfigurationPlugin/Handlers/eFormCompletedHandler.cs
@@ -23,6 +23,7 @@ SOFTWARE.
 */
 
 using Rebus.Bus;
+using ServiceBackendConfigurationPlugin.Infrastructure;
 
 namespace ServiceBackendConfigurationPlugin.Handlers;
 
@@ -286,6 +287,15 @@ public class EFormCompletedHandler(
 
 
                 var deadline = ((DateTime) planning.NextExecutionTime);
+                var arpForDeadline = await backendConfigurationPnDbContext.AreaRulePlannings
+                    .Where(x => x.ItemPlanningId == planningCaseSite.PlanningId)
+                    .AsNoTracking().FirstOrDefaultAsync();
+                if (arpForDeadline?.RepeatOrdinalWeek is > 0)
+                {
+                    var snapped = RecurrenceHelper.NthWeekdayOfMonth(
+                        deadline.Year, deadline.Month, arpForDeadline.RepeatOrdinalWeek.Value, arpForDeadline.DayOfWeek);
+                    if (snapped != null) deadline = snapped.Value;
+                }
                 Console.WriteLine($"info: Deadline: {deadline}");
                 // backendConfigurationPnDbContext.Database.Log = Console.Write;
 

--- a/ServiceBackendConfigurationPlugin/Infrastructure/RecurrenceHelper.cs
+++ b/ServiceBackendConfigurationPlugin/Infrastructure/RecurrenceHelper.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace ServiceBackendConfigurationPlugin.Infrastructure;
+
+public static class RecurrenceHelper
+{
+    // ordinal: 1..5 (1 = first). targetDow: 0=Sun..6=Sat (matches System.DayOfWeek).
+    public static DateTime? NthWeekdayOfMonth(int year, int month, int ordinal, int targetDow)
+    {
+        var firstOfMonth = new DateTime(year, month, 1, 0, 0, 0, DateTimeKind.Utc);
+        int dowOffset = (targetDow - (int)firstOfMonth.DayOfWeek + 7) % 7;
+        var candidate = firstOfMonth.AddDays(dowOffset + (ordinal - 1) * 7);
+        return candidate.Month != month ? null : candidate;
+    }
+}

--- a/ServiceBackendConfigurationPlugin/ServiceBackendConfigurationPlugin.csproj
+++ b/ServiceBackendConfigurationPlugin/ServiceBackendConfigurationPlugin.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microting.EformAngularFrontendBase" Version="10.0.35" />
     <PackageReference Include="Microting.EformBackendConfigurationBase" Version="10.0.44" />
     <PackageReference Include="Microting.eFormCaseTemplateBase" Version="10.0.33" />
-    <PackageReference Include="Microting.ItemsPlanningBase" Version="10.0.34" />
+    <PackageReference Include="Microting.ItemsPlanningBase" Version="10.0.35" />
     <PackageReference Include="Microting.WindowsService.BasePn" Version="2.0.0" />
     <PackageReference Include="QuestPDF" Version="2026.6.0" />
     <PackageReference Include="SendGrid" Version="9.29.3" />

--- a/ci/eformparsed/eformparsed.csproj
+++ b/ci/eformparsed/eformparsed.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microting.eForm" Version="10.0.35" />
     <PackageReference Include="Microting.EformBackendConfigurationBase" Version="10.0.44" />
-    <PackageReference Include="Microting.ItemsPlanningBase" Version="10.0.34" />
+    <PackageReference Include="Microting.ItemsPlanningBase" Version="10.0.35" />
     <PackageReference Include="Microting.Rebus" Version="10.0.3" />
     <PackageReference Include="Microting.Rebus.Castle.Windsor" Version="10.0.5" />
     <PackageReference Include="Microting.Rebus.RabbitMq" Version="10.0.5" />


### PR DESCRIPTION
Stops the service plugin from writing a stale day-of-month `Compliance.Deadline` for ordinal-week monthly rules. Adds `RecurrenceHelper.NthWeekdayOfMonth`; `EformParsedByServerHandler` (both the NextExecutionTime calc and the Compliance-creation deadline — defense-in-depth, since the calc is gated on NextExecutionTime==null), `Core.cs`, and the retraction in `eFormCompletedHandler` all snap the deadline from `areaRulePlanning.RepeatOrdinalWeek`. Bumps `Microting.ItemsPlanningBase` →10.0.35.

Part of the fix for duplicate ordinal-week calendar occurrences. Verified live: event 70 now shows only on Thursday Jul 16, not Saturday Jul 18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)