### PR TITLE
Hourly AdhocReminderJob: adhoc-task reminder evaluation + FCM push delivery

### DIFF
--- a/Dockerfile-service
+++ b/Dockerfile-service
@@ -14,6 +14,11 @@ COPY eform-service-items-planning-plugin ./eform-service-items-planning-plugin
 COPY eform-service-workflow-plugin ./eform-service-workflow-plugin
 COPY eform-service-timeplanning-plugin ./eform-service-timeplanning-plugin
 COPY eform-service-backendconfiguration-plugin ./eform-service-backendconfiguration-plugin
+# The host must ship Microsoft.Bcl.AsyncInterfaces >= 6.0.0.0: MEF loads plugin assemblies
+# into the default load context, where dependencies resolve against the host's closure first.
+# FirebaseAdmin -> Google.Api.Gax references AsyncInterfaces 6.0.0.0, but the host only pulls
+# 5.0.0.0 transitively (System.Private.ServiceModel 4.10.3), which fails with 0x80131040.
+RUN dotnet add eform-debian-service/MicrotingService/MicrotingService.csproj package Microsoft.Bcl.AsyncInterfaces --version 10.0.10
 RUN dotnet publish -o out /p:Version=$GITVERSION --runtime linux-x64 --configuration Release eform-debian-service
 RUN dotnet publish -o out/Plugins/ServiceItemsPlanningPlugin /p:Version=$PLUGINVERSION --runtime linux-x64 --configuration Release eform-service-items-planning-plugin
 RUN dotnet publish -o out/Plugins/ServiceWorkflowPlugin /p:Version=$PLUGIN3VERSION --runtime linux-x64 --configuration Release eform-service-workflow-plugin

--- a/ServiceBackendConfigurationPlugin.Integration.Test/AdhocReminderEvaluatorTests.cs
+++ b/ServiceBackendConfigurationPlugin.Integration.Test/AdhocReminderEvaluatorTests.cs
@@ -1,0 +1,317 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2026 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+namespace ServiceBackendConfigurationPlugin.Integration.Test
+{
+    using System;
+    using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+    using NUnit.Framework;
+    using ServiceBackendConfigurationPlugin.Infrastructure.Helpers;
+
+    [TestFixture]
+    public class AdhocReminderEvaluatorTests
+    {
+        // 2026-07-20 is a Monday; the surrounding week gives us every
+        // weekday/weekend combination the repeat logic cares about.
+        private static readonly DateTime Monday = new(2026, 7, 20);
+        private static readonly DateTime Friday = new(2026, 7, 24);
+        private static readonly DateTime Saturday = new(2026, 7, 25);
+        private static readonly DateTime Sunday = new(2026, 7, 26);
+
+        private static AdhocTaskEntity VisibleReminderTask(
+            DateTime visibleFrom, int timeMinutes = 480, DateTime? lastSentAt = null)
+        {
+            return new AdhocTaskEntity
+            {
+                VisibleReminder = true,
+                VisibleFrom = visibleFrom,
+                VisibleReminderTimeMinutes = timeMinutes,
+                LastVisibleReminderSentAt = lastSentAt
+            };
+        }
+
+        private static AdhocTaskEntity DeadlineReminderTask(
+            DateTime deadline, int repeat = 0, int timeMinutes = 480, DateTime? lastSentAt = null)
+        {
+            return new AdhocTaskEntity
+            {
+                DeadlineReminder = true,
+                Deadline = deadline,
+                DeadlineReminderRepeat = repeat,
+                DeadlineReminderTimeMinutes = timeMinutes,
+                LastDeadlineReminderSentAt = lastSentAt
+            };
+        }
+
+        // --- visible-from reminder -------------------------------------
+
+        [Test]
+        public void Visible_DueAtDefaultEightOClock()
+        {
+            var task = VisibleReminderTask(Monday);
+
+            Assert.That(
+                AdhocReminderEvaluator.DueVisibleReminderInstant(task, Monday.AddHours(8)),
+                Is.EqualTo(Monday.AddHours(8)));
+        }
+
+        [Test]
+        public void Visible_NotDueBeforeReminderTime()
+        {
+            var task = VisibleReminderTask(Monday);
+
+            Assert.That(
+                AdhocReminderEvaluator.DueVisibleReminderInstant(task, Monday.AddHours(7)),
+                Is.Null);
+        }
+
+        [Test]
+        public void Visible_NotDueWhenFlagOffOrDateMissing()
+        {
+            var flagOff = VisibleReminderTask(Monday);
+            flagOff.VisibleReminder = false;
+            var dateMissing = VisibleReminderTask(Monday);
+            dateMissing.VisibleFrom = null;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    AdhocReminderEvaluator.DueVisibleReminderInstant(flagOff, Monday.AddHours(9)),
+                    Is.Null);
+                Assert.That(
+                    AdhocReminderEvaluator.DueVisibleReminderInstant(dateMissing, Monday.AddHours(9)),
+                    Is.Null);
+            });
+        }
+
+        [Test]
+        public void Visible_MarkerAtOrAfterInstantSuppresses()
+        {
+            var task = VisibleReminderTask(Monday, lastSentAt: Monday.AddHours(8).AddMinutes(5));
+
+            Assert.That(
+                AdhocReminderEvaluator.DueVisibleReminderInstant(task, Monday.AddHours(9)),
+                Is.Null);
+        }
+
+        [Test]
+        public void Visible_StaleMarkerBeforeInstantStillFires()
+        {
+            // Marker from an earlier (edited-away) reminder date must not
+            // suppress the current instant.
+            var task = VisibleReminderTask(Monday, lastSentAt: Monday.AddDays(-3).AddHours(8));
+
+            Assert.That(
+                AdhocReminderEvaluator.DueVisibleReminderInstant(task, Monday.AddHours(9)),
+                Is.EqualTo(Monday.AddHours(8)));
+        }
+
+        [Test]
+        public void Visible_CustomReminderTimeMinutesIsRespected()
+        {
+            var task = VisibleReminderTask(Monday, timeMinutes: 930); // 15:30
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    AdhocReminderEvaluator.DueVisibleReminderInstant(task, Monday.AddHours(15)),
+                    Is.Null);
+                Assert.That(
+                    AdhocReminderEvaluator.DueVisibleReminderInstant(task, Monday.AddHours(16)),
+                    Is.EqualTo(Monday.AddMinutes(930)));
+            });
+        }
+
+        [Test]
+        public void Visible_TimeOfDayOnVisibleFromIsIgnored()
+        {
+            // The instant is the DATE at *ReminderTimeMinutes — an afternoon
+            // timestamp on VisibleFrom must not push the instant.
+            var task = VisibleReminderTask(Monday.AddHours(17));
+
+            Assert.That(
+                AdhocReminderEvaluator.DueVisibleReminderInstant(task, Monday.AddHours(9)),
+                Is.EqualTo(Monday.AddHours(8)));
+        }
+
+        [Test]
+        public void Visible_LateCatchUpStillFiresDaysAfter()
+        {
+            var task = VisibleReminderTask(Monday);
+
+            Assert.That(
+                AdhocReminderEvaluator.DueVisibleReminderInstant(task, Monday.AddDays(4).AddHours(12)),
+                Is.EqualTo(Monday.AddHours(8)));
+        }
+
+        // --- deadline reminder, fire once (Repeat == 0) -----------------
+
+        [Test]
+        public void DeadlineOnce_DueAtInstantAndSuppressedByMarker()
+        {
+            var due = DeadlineReminderTask(Friday);
+            var sent = DeadlineReminderTask(Friday, lastSentAt: Friday.AddHours(8).AddMinutes(10));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    AdhocReminderEvaluator.DueDeadlineReminderInstant(due, Friday.AddHours(8)),
+                    Is.EqualTo(Friday.AddHours(8)));
+                Assert.That(
+                    AdhocReminderEvaluator.DueDeadlineReminderInstant(sent, Friday.AddHours(9)),
+                    Is.Null);
+            });
+        }
+
+        [Test]
+        public void DeadlineOnce_NotDueBeforeInstant()
+        {
+            var task = DeadlineReminderTask(Friday);
+
+            Assert.That(
+                AdhocReminderEvaluator.DueDeadlineReminderInstant(task, Friday.AddHours(7)),
+                Is.Null);
+        }
+
+        [Test]
+        public void DeadlineOnce_DoesNotRefireOnLaterDays()
+        {
+            var task = DeadlineReminderTask(Friday, lastSentAt: Friday.AddHours(8).AddMinutes(10));
+
+            Assert.That(
+                AdhocReminderEvaluator.DueDeadlineReminderInstant(task, Friday.AddDays(3).AddHours(9)),
+                Is.Null);
+        }
+
+        [Test]
+        public void DeadlineOnce_LateCatchUpStillFires()
+        {
+            var task = DeadlineReminderTask(Friday);
+
+            Assert.That(
+                AdhocReminderEvaluator.DueDeadlineReminderInstant(task, Sunday.AddHours(14)),
+                Is.EqualTo(Friday.AddHours(8)));
+        }
+
+        [Test]
+        public void Deadline_NotDueWhenFlagOffOrDateMissing()
+        {
+            var flagOff = DeadlineReminderTask(Friday);
+            flagOff.DeadlineReminder = false;
+            var dateMissing = DeadlineReminderTask(Friday);
+            dateMissing.Deadline = null;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    AdhocReminderEvaluator.DueDeadlineReminderInstant(flagOff, Friday.AddHours(9)),
+                    Is.Null);
+                Assert.That(
+                    AdhocReminderEvaluator.DueDeadlineReminderInstant(dateMissing, Friday.AddHours(9)),
+                    Is.Null);
+            });
+        }
+
+        // --- deadline reminder, weekday repeat (Repeat == 1) ------------
+
+        [Test]
+        public void DeadlineRepeat_FiresOnDeadlineDayEvenOnWeekend()
+        {
+            // The deadline-day fire mirrors Repeat == 0 (no weekday guard).
+            var task = DeadlineReminderTask(Saturday, repeat: 1);
+
+            Assert.That(
+                AdhocReminderEvaluator.DueDeadlineReminderInstant(task, Saturday.AddHours(9)),
+                Is.EqualTo(Saturday.AddHours(8)));
+        }
+
+        [Test]
+        public void DeadlineRepeat_SkipsWeekendAfterDeadline()
+        {
+            var task = DeadlineReminderTask(Friday, repeat: 1, lastSentAt: Friday.AddHours(8).AddMinutes(10));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    AdhocReminderEvaluator.DueDeadlineReminderInstant(task, Saturday.AddHours(9)),
+                    Is.Null);
+                Assert.That(
+                    AdhocReminderEvaluator.DueDeadlineReminderInstant(task, Sunday.AddHours(9)),
+                    Is.Null);
+            });
+        }
+
+        [Test]
+        public void DeadlineRepeat_RefiresNextWeekday()
+        {
+            var task = DeadlineReminderTask(Friday, repeat: 1, lastSentAt: Friday.AddHours(8).AddMinutes(10));
+            var nextMonday = Friday.AddDays(3);
+
+            Assert.That(
+                AdhocReminderEvaluator.DueDeadlineReminderInstant(task, nextMonday.AddHours(8)),
+                Is.EqualTo(nextMonday.AddHours(8)));
+        }
+
+        [Test]
+        public void DeadlineRepeat_OncePerDay()
+        {
+            var nextMonday = Friday.AddDays(3);
+            var task = DeadlineReminderTask(
+                Friday, repeat: 1, lastSentAt: nextMonday.AddHours(8).AddMinutes(10));
+
+            Assert.Multiple(() =>
+            {
+                // Same day, later hour: suppressed by today's marker.
+                Assert.That(
+                    AdhocReminderEvaluator.DueDeadlineReminderInstant(task, nextMonday.AddHours(15)),
+                    Is.Null);
+                // Next weekday: due again.
+                Assert.That(
+                    AdhocReminderEvaluator.DueDeadlineReminderInstant(task, nextMonday.AddDays(1).AddHours(9)),
+                    Is.EqualTo(nextMonday.AddDays(1).AddHours(8)));
+            });
+        }
+
+        [Test]
+        public void DeadlineRepeat_NotDueBeforeTodaysSlot()
+        {
+            var task = DeadlineReminderTask(Friday, repeat: 1, lastSentAt: Friday.AddHours(8).AddMinutes(10));
+            var nextMonday = Friday.AddDays(3);
+
+            Assert.That(
+                AdhocReminderEvaluator.DueDeadlineReminderInstant(task, nextMonday.AddHours(7)),
+                Is.Null);
+        }
+
+        [Test]
+        public void DeadlineRepeat_NotDueBeforeDeadline()
+        {
+            var task = DeadlineReminderTask(Friday, repeat: 1);
+
+            Assert.That(
+                AdhocReminderEvaluator.DueDeadlineReminderInstant(task, Monday.AddHours(9)),
+                Is.Null);
+        }
+    }
+}

--- a/ServiceBackendConfigurationPlugin.Integration.Test/AdhocReminderEvaluatorTests.cs
+++ b/ServiceBackendConfigurationPlugin.Integration.Test/AdhocReminderEvaluatorTests.cs
@@ -313,5 +313,130 @@ namespace ServiceBackendConfigurationPlugin.Integration.Test
                 AdhocReminderEvaluator.DueDeadlineReminderInstant(task, Monday.AddHours(9)),
                 Is.Null);
         }
+
+        // --- marker-write policy (ShouldWriteMarker) ---------------------
+
+        [Test]
+        public void Marker_OneShot_ZeroDeliveries_IsNotWritten()
+        {
+            Assert.Multiple(() =>
+            {
+                // Visible reminder is always one-shot...
+                Assert.That(
+                    AdhocReminderEvaluator.ShouldWriteMarker(
+                        isDeadlineReminder: false, deadlineReminderRepeat: 0,
+                        deliveredCount: 0, transientFailures: 0),
+                    Is.False);
+                // ...even when the task's DEADLINE repeat is weekdays.
+                Assert.That(
+                    AdhocReminderEvaluator.ShouldWriteMarker(
+                        isDeadlineReminder: false, deadlineReminderRepeat: 1,
+                        deliveredCount: 0, transientFailures: 0),
+                    Is.False);
+                // Deadline reminder with Repeat == 0 is one-shot too.
+                Assert.That(
+                    AdhocReminderEvaluator.ShouldWriteMarker(
+                        isDeadlineReminder: true, deadlineReminderRepeat: 0,
+                        deliveredCount: 0, transientFailures: 0),
+                    Is.False);
+            });
+        }
+
+        [Test]
+        public void Marker_OneShot_AllTokensDead_IsNotWritten()
+        {
+            // Every token purged as UNREGISTERED/invalid -> deliveredCount 0
+            // with no transient failures: same rule as having no tokens at
+            // all — the single delivery attempt must not be consumed.
+            Assert.That(
+                AdhocReminderEvaluator.ShouldWriteMarker(
+                    isDeadlineReminder: true, deadlineReminderRepeat: 0,
+                    deliveredCount: 0, transientFailures: 0),
+                Is.False);
+        }
+
+        [Test]
+        public void Marker_WeekdayRepeat_ZeroDeliveries_IsWritten()
+        {
+            // Self-heals next weekday, so today's slot may be marked done.
+            Assert.That(
+                AdhocReminderEvaluator.ShouldWriteMarker(
+                    isDeadlineReminder: true, deadlineReminderRepeat: 1,
+                    deliveredCount: 0, transientFailures: 0),
+                Is.True);
+        }
+
+        [Test]
+        public void Marker_AnyDelivery_IsWritten()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    AdhocReminderEvaluator.ShouldWriteMarker(
+                        isDeadlineReminder: false, deadlineReminderRepeat: 0,
+                        deliveredCount: 1, transientFailures: 0),
+                    Is.True);
+                Assert.That(
+                    AdhocReminderEvaluator.ShouldWriteMarker(
+                        isDeadlineReminder: true, deadlineReminderRepeat: 1,
+                        deliveredCount: 3, transientFailures: 0),
+                    Is.True);
+            });
+        }
+
+        [Test]
+        public void Marker_TransientFailures_AlwaysBlock()
+        {
+            Assert.Multiple(() =>
+            {
+                // Even with deliveries, a transient failure defers the marker
+                // so the stragglers retry next hour.
+                Assert.That(
+                    AdhocReminderEvaluator.ShouldWriteMarker(
+                        isDeadlineReminder: false, deadlineReminderRepeat: 0,
+                        deliveredCount: 5, transientFailures: 1),
+                    Is.False);
+                Assert.That(
+                    AdhocReminderEvaluator.ShouldWriteMarker(
+                        isDeadlineReminder: true, deadlineReminderRepeat: 1,
+                        deliveredCount: 0, transientFailures: 2),
+                    Is.False);
+            });
+        }
+
+        [Test]
+        public void Marker_OneShotRetriesHourlyUntilDelivered()
+        {
+            // Tick 1 (09:00): due, but zero live tokens -> policy says no
+            // marker; the task stays due on later ticks the same day.
+            var task = VisibleReminderTask(Monday);
+            var dueInstant = Monday.AddHours(8);
+
+            Assert.That(
+                AdhocReminderEvaluator.DueVisibleReminderInstant(task, Monday.AddHours(9)),
+                Is.EqualTo(dueInstant));
+            Assert.That(
+                AdhocReminderEvaluator.ShouldWriteMarker(
+                    isDeadlineReminder: false, deadlineReminderRepeat: 0,
+                    deliveredCount: 0, transientFailures: 0),
+                Is.False);
+
+            // Tick 2 (10:00): still due — a token registered in between now
+            // receives the reminder, and the marker gets written.
+            Assert.That(
+                AdhocReminderEvaluator.DueVisibleReminderInstant(task, Monday.AddHours(10)),
+                Is.EqualTo(dueInstant));
+            Assert.That(
+                AdhocReminderEvaluator.ShouldWriteMarker(
+                    isDeadlineReminder: false, deadlineReminderRepeat: 0,
+                    deliveredCount: 1, transientFailures: 0),
+                Is.True);
+            task.LastVisibleReminderSentAt = Monday.AddHours(10);
+
+            // Tick 3 (11:00): suppressed by the marker.
+            Assert.That(
+                AdhocReminderEvaluator.DueVisibleReminderInstant(task, Monday.AddHours(11)),
+                Is.Null);
+        }
     }
 }

--- a/ServiceBackendConfigurationPlugin/Core.cs
+++ b/ServiceBackendConfigurationPlugin/Core.cs
@@ -295,6 +295,7 @@ public class Core : ISdkEventHandler
                     , new RebusInstaller(dbPrefix, connectionString, _maxParallelism, _numberOfWorkers, rabbitMqUser, rabbitMqPassword, rabbitmqHost)
                 );
                 _container.Register(Component.For<SearchListJob>());
+                _container.Register(Component.For<AdhocReminderJob>());
                 _container.Register(Component.For<DriveChannelRenewalJob>());
                 _container.Register(Component.For<DriveTokenKeepaliveJob>());
                 _container.Register(Component.For<DriveReconcileJob>());
@@ -467,9 +468,32 @@ public class Core : ISdkEventHandler
     {
         var job = _container.Resolve<SearchListJob>();
 
+        // Each hourly job gets its own try/catch (same pattern as the Drive
+        // daily chain below) so a failure in one doesn't sink the other —
+        // and doesn't escape the async void timer callback.
         async void Callback(object x)
         {
-            await job.Execute();
+            try
+            {
+                await job.Execute();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"fail: SearchListJob - {e.Message}");
+                SentrySdk.CaptureException(e);
+            }
+
+            // Adhoc reminder evaluation + FCM push delivery piggybacks on
+            // the same hourly timer (feature-flag gated inside the job).
+            try
+            {
+                await _container.Resolve<AdhocReminderJob>().Execute();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"fail: AdhocReminderJob - {e.Message}");
+                SentrySdk.CaptureException(e);
+            }
         }
 
         _scheduleTimer = new Timer(Callback, null, TimeSpan.Zero, TimeSpan.FromMinutes(60));

--- a/ServiceBackendConfigurationPlugin/Infrastructure/Helpers/AdhocReminderEvaluator.cs
+++ b/ServiceBackendConfigurationPlugin/Infrastructure/Helpers/AdhocReminderEvaluator.cs
@@ -1,0 +1,132 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2026 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+
+namespace ServiceBackendConfigurationPlugin.Infrastructure.Helpers;
+
+/// <summary>
+/// Pure due-instant evaluation for adhoc-task reminder pushes.
+///
+/// A reminder instant is the reminder DATE (VisibleFrom/Deadline) at
+/// <c>*ReminderTimeMinutes</c> from midnight (default 480 = 08:00), compared
+/// in server-local time. A reminder is DUE when <paramref name="now"/> has
+/// passed the instant AND the corresponding <c>Last*ReminderSentAt</c> marker
+/// has not been written at/after that instant — the marker comparison is what
+/// makes the hourly <see cref="Scheduler.Jobs.AdhocReminderJob"/> idempotent.
+///
+/// <c>DeadlineReminderRepeat == 1</c> ("hverdage") re-fires every weekday
+/// (Mon-Fri) after the deadline until the task is completed/archived; the
+/// per-day marker comparison gives once-per-day idempotency. Repeat == 0
+/// fires once (late catch-up allowed — the instant is fixed, so a task
+/// evaluated after its instant still fires until the marker is set).
+///
+/// Kept free of DbContext/clock/Firebase dependencies so it is unit-testable.
+/// </summary>
+public static class AdhocReminderEvaluator
+{
+    /// <summary>
+    /// Returns the due instant for the visible-from reminder when a send is
+    /// currently due, otherwise null.
+    /// </summary>
+    public static DateTime? DueVisibleReminderInstant(AdhocTaskEntity task, DateTime now)
+    {
+        if (!task.VisibleReminder || task.VisibleFrom == null)
+        {
+            return null;
+        }
+
+        var dueInstant = task.VisibleFrom.Value.Date.AddMinutes(task.VisibleReminderTimeMinutes);
+        if (now < dueInstant)
+        {
+            return null;
+        }
+
+        return IsMarkerStale(task.LastVisibleReminderSentAt, dueInstant) ? dueInstant : null;
+    }
+
+    /// <summary>
+    /// Returns the due instant for the deadline reminder when a send is
+    /// currently due, otherwise null.
+    /// </summary>
+    public static DateTime? DueDeadlineReminderInstant(AdhocTaskEntity task, DateTime now)
+    {
+        if (!task.DeadlineReminder || task.Deadline == null)
+        {
+            return null;
+        }
+
+        var deadlineDate = task.Deadline.Value.Date;
+        var firstInstant = deadlineDate.AddMinutes(task.DeadlineReminderTimeMinutes);
+        if (now < firstInstant)
+        {
+            return null;
+        }
+
+        if (task.DeadlineReminderRepeat != 1)
+        {
+            // Fire once. The instant is fixed at the deadline date, so a
+            // missed hour (or a whole missed day) still catches up until the
+            // marker is written.
+            return IsMarkerStale(task.LastDeadlineReminderSentAt, firstInstant) ? firstInstant : null;
+        }
+
+        // Weekday repeat ("hverdage"): the deadline-day fire itself is NOT
+        // weekday-guarded (mirrors Repeat == 0 semantics); every day after
+        // the deadline only weekdays re-fire, and only once today's slot has
+        // been reached — a slot missed for a whole day is skipped, not
+        // replayed the following morning.
+        DateTime currentInstant;
+        if (now.Date == deadlineDate)
+        {
+            currentInstant = firstInstant;
+        }
+        else
+        {
+            if (!IsWeekday(now.DayOfWeek))
+            {
+                return null;
+            }
+
+            currentInstant = now.Date.AddMinutes(task.DeadlineReminderTimeMinutes);
+            if (now < currentInstant)
+            {
+                return null;
+            }
+        }
+
+        return IsMarkerStale(task.LastDeadlineReminderSentAt, currentInstant) ? currentInstant : null;
+    }
+
+    private static bool IsMarkerStale(DateTime? lastSentAt, DateTime dueInstant)
+    {
+        return lastSentAt == null || lastSentAt.Value < dueInstant;
+    }
+
+    private static bool IsWeekday(DayOfWeek dayOfWeek)
+    {
+        return dayOfWeek != DayOfWeek.Saturday && dayOfWeek != DayOfWeek.Sunday;
+    }
+}

--- a/ServiceBackendConfigurationPlugin/Infrastructure/Helpers/AdhocReminderEvaluator.cs
+++ b/ServiceBackendConfigurationPlugin/Infrastructure/Helpers/AdhocReminderEvaluator.cs
@@ -120,6 +120,37 @@ public static class AdhocReminderEvaluator
         return IsMarkerStale(task.LastDeadlineReminderSentAt, currentInstant) ? currentInstant : null;
     }
 
+    /// <summary>
+    /// Decides whether the <c>Last*ReminderSentAt</c> marker may be written
+    /// after a send attempt.
+    ///
+    /// Any transient failure blocks the marker (whole task+kind retries next
+    /// hour). Any actual delivery writes it. With ZERO deliveries (no
+    /// registered tokens, or every token was dead and got purged) the kind
+    /// matters: a weekday-repeat deadline reminder self-heals next weekday,
+    /// so today's slot may be marked done; a ONE-SHOT reminder
+    /// (visible-from, or deadline with Repeat != 1) has a fixed instant that
+    /// never recurs — writing the marker would permanently and silently lose
+    /// the only delivery attempt, so it stays unset and the job retries
+    /// hourly until a live token exists (bounded: completed/archived tasks
+    /// drop out of the candidate query).
+    /// </summary>
+    public static bool ShouldWriteMarker(
+        bool isDeadlineReminder, int deadlineReminderRepeat, int deliveredCount, int transientFailures)
+    {
+        if (transientFailures > 0)
+        {
+            return false;
+        }
+
+        if (deliveredCount > 0)
+        {
+            return true;
+        }
+
+        return isDeadlineReminder && deadlineReminderRepeat == 1;
+    }
+
     private static bool IsMarkerStale(DateTime? lastSentAt, DateTime dueInstant)
     {
         return lastSentAt == null || lastSentAt.Value < dueInstant;

--- a/ServiceBackendConfigurationPlugin/Scheduler/Jobs/AdhocReminderJob.cs
+++ b/ServiceBackendConfigurationPlugin/Scheduler/Jobs/AdhocReminderJob.cs
@@ -1,0 +1,345 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2007 - 2026 Microting A/S
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FirebaseAdmin;
+using FirebaseAdmin.Messaging;
+using Google.Apis.Auth.OAuth2;
+using Microsoft.EntityFrameworkCore;
+using Microting.eForm.Infrastructure.Constants;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data;
+using Microting.EformBackendConfigurationBase.Infrastructure.Data.Entities;
+using Sentry;
+using ServiceBackendConfigurationPlugin.Infrastructure.Helpers;
+
+namespace ServiceBackendConfigurationPlugin.Scheduler.Jobs;
+
+/// <summary>
+/// Hourly reminder evaluation + FCM push delivery for adhoc tasks.
+///
+/// Runs on the same hourly <c>_scheduleTimer</c> as <see cref="SearchListJob"/>
+/// (see <c>Core.ConfigureScheduler</c>). Feature-flag gated via the
+/// <c>BackendConfigurationSettings:AdhocReminderPushEnabled</c>
+/// PluginConfigurationValues row (same convention as
+/// ComplianceOverdueMovementEnabled) — exits quietly when disabled/unset.
+///
+/// Due evaluation is delegated to <see cref="AdhocReminderEvaluator"/> in
+/// server-local time. Recipients are the task's non-removed
+/// <c>AdhocTaskAssignments</c> worker ids, widened to all non-removed
+/// <c>PropertyWorkers</c> of the task's property when
+/// <c>ExecutionRule == 1</c> (everyone). FCM tokens come from
+/// <c>DeviceTokens</c> (WorkflowState == Created).
+///
+/// Idempotency: the task's <c>Last*ReminderSentAt</c> marker is written only
+/// AFTER a send batch with no transient failures; a transient failure leaves
+/// the marker unset so the whole task+kind retries next hour. Per-token
+/// permanent failures (UNREGISTERED / INVALID_ARGUMENT) soft-delete that
+/// DeviceToken row and do not block the marker.
+///
+/// Firebase credentials (service-account JSON) load from the
+/// <c>BackendConfigurationSettings:AdhocFirebaseServiceAccountJson</c>
+/// PluginConfigurationValues row; when unset the job logs once and no-ops.
+/// </summary>
+public class AdhocReminderJob : IJob
+{
+    private const string FeatureFlagKey =
+        "BackendConfigurationSettings:AdhocReminderPushEnabled";
+
+    private const string ServiceAccountJsonKey =
+        "BackendConfigurationSettings:AdhocFirebaseServiceAccountJson";
+
+    // Must match the Android notification channel the mobile app creates.
+    private const string AndroidChannelId = "high_importance_channel";
+
+    // FCM rejects SendEach batches above 500 messages.
+    private const int FcmBatchLimit = 500;
+
+    // FirebaseApp.Create throws on double-init; the guard makes the hourly
+    // ticks (and any future co-hosted sender) initialize exactly once.
+    private static readonly object FirebaseInitLock = new();
+
+    // "Log once + skip" latch for missing credentials; resets when the key
+    // appears so a later removal logs again.
+    private static bool _missingCredentialsLogged;
+
+    private readonly BackendConfigurationDbContextHelper _dbContextHelper;
+
+    public AdhocReminderJob(BackendConfigurationDbContextHelper dbContextHelper)
+    {
+        _dbContextHelper = dbContextHelper;
+    }
+
+    public async Task Execute()
+    {
+        try
+        {
+            await ExecuteInner();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"fail: AdhocReminderJob - {e.Message}");
+            SentrySdk.CaptureException(e);
+        }
+    }
+
+    private async Task ExecuteInner()
+    {
+        await using var db = _dbContextHelper.GetDbContext();
+
+        var featureFlag = await db.PluginConfigurationValues
+            .FirstOrDefaultAsync(x => x.Name == FeatureFlagKey);
+        if (featureFlag == null || !bool.TryParse(featureFlag.Value, out var isEnabled) || !isEnabled)
+        {
+            return;
+        }
+
+        // Reminder instants are defined in server-local time by design
+        // (Europe/Copenhagen deployments).
+        var now = DateTime.Now;
+
+        var candidates = await db.AdhocTasks
+            .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+            .Where(x => !x.Completed)
+            .Where(x => !x.Archived)
+            .Where(x => (x.VisibleReminder && x.VisibleFrom != null)
+                        || (x.DeadlineReminder && x.Deadline != null))
+            .ToListAsync();
+
+        var dueReminders = new List<(AdhocTaskEntity Task, bool IsDeadline)>();
+        foreach (var task in candidates)
+        {
+            if (AdhocReminderEvaluator.DueVisibleReminderInstant(task, now) != null)
+            {
+                dueReminders.Add((task, false));
+            }
+
+            if (AdhocReminderEvaluator.DueDeadlineReminderInstant(task, now) != null)
+            {
+                dueReminders.Add((task, true));
+            }
+        }
+
+        if (dueReminders.Count == 0)
+        {
+            return;
+        }
+
+        var serviceAccountJson = (await db.PluginConfigurationValues
+            .FirstOrDefaultAsync(x => x.Name == ServiceAccountJsonKey))?.Value;
+        if (string.IsNullOrEmpty(serviceAccountJson))
+        {
+            if (!_missingCredentialsLogged)
+            {
+                Console.WriteLine(
+                    $"warn: AdhocReminderJob - {ServiceAccountJsonKey} is not set; " +
+                    $"skipping {dueReminders.Count} due reminder(s)");
+                _missingCredentialsLogged = true;
+            }
+
+            return;
+        }
+
+        _missingCredentialsLogged = false;
+
+        EnsureFirebaseApp(serviceAccountJson);
+
+        foreach (var (task, isDeadline) in dueReminders)
+        {
+            try
+            {
+                await SendReminderForTask(db, task, isDeadline, now);
+            }
+            catch (Exception e)
+            {
+                // A failing task leaves its marker unset and retries next
+                // hour; it must not sink the remaining due reminders.
+                Console.WriteLine($"fail: AdhocReminderJob task {task.Id} - {e.Message}");
+                SentrySdk.CaptureException(e);
+            }
+        }
+    }
+
+    private static async Task SendReminderForTask(
+        BackendConfigurationPnDbContext db, AdhocTaskEntity task, bool isDeadlineReminder, DateTime now)
+    {
+        List<int> workerIds;
+        if (task.ExecutionRule == 1)
+        {
+            // 1 = everyone: all workers of the task's property.
+            workerIds = await db.PropertyWorkers
+                .Where(x => x.PropertyId == task.PropertyId)
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .Select(x => x.WorkerId)
+                .Distinct()
+                .ToListAsync();
+        }
+        else
+        {
+            workerIds = await db.AdhocTaskAssignments
+                .Where(x => x.AdhocTaskId == task.Id)
+                .Where(x => x.WorkflowState != Constants.WorkflowStates.Removed)
+                .Select(x => x.WorkerId)
+                .Distinct()
+                .ToListAsync();
+        }
+
+        var tokens = workerIds.Count == 0
+            ? new List<DeviceToken>()
+            : await db.DeviceTokens
+                .Where(x => x.WorkflowState == Constants.WorkflowStates.Created)
+                .Where(x => workerIds.Contains(x.WorkerId))
+                .ToListAsync();
+
+        if (tokens.Count > 0)
+        {
+            var title = string.IsNullOrWhiteSpace(task.Title) ? "Opgave" : task.Title;
+            // Due evaluation guarantees the corresponding date is non-null.
+            var body = isDeadlineReminder
+                ? $"Påmindelse: Opgaven har deadline {task.Deadline!.Value:dd-MM-yyyy}"
+                : $"Påmindelse: Opgaven er synlig fra {task.VisibleFrom!.Value:dd-MM-yyyy}";
+
+            var messages = tokens.Select(deviceToken => new Message
+            {
+                // Message.Token is marked obsolete in FirebaseAdmin 3.6 in
+                // favor of Fid, but Fid serializes to the "fid" field
+                // (Firebase installation-id targeting) — a DIFFERENT wire
+                // field. DeviceTokens stores FCM registration tokens, which
+                // the FCM v1 API only accepts via "token".
+#pragma warning disable CS0618
+                Token = deviceToken.FcmToken,
+#pragma warning restore CS0618
+                Notification = new Notification
+                {
+                    Title = title,
+                    Body = body
+                },
+                // The mobile PushRouter routes on exactly this key.
+                Data = new Dictionary<string, string>
+                {
+                    ["taskId"] = task.Id.ToString()
+                },
+                Android = new AndroidConfig
+                {
+                    Priority = Priority.High,
+                    Notification = new AndroidNotification
+                    {
+                        ChannelId = AndroidChannelId
+                    }
+                }
+            }).ToList();
+
+            var transientFailures = 0;
+            for (var offset = 0; offset < messages.Count; offset += FcmBatchLimit)
+            {
+                var chunk = messages.Skip(offset).Take(FcmBatchLimit).ToList();
+                var batch = await FirebaseMessaging.DefaultInstance.SendEachAsync(chunk);
+
+                for (var i = 0; i < batch.Responses.Count; i++)
+                {
+                    var response = batch.Responses[i];
+                    if (response.IsSuccess)
+                    {
+                        continue;
+                    }
+
+                    var deviceToken = tokens[offset + i];
+                    var errorCode = response.Exception?.MessagingErrorCode;
+                    if (errorCode is MessagingErrorCode.Unregistered or MessagingErrorCode.InvalidArgument)
+                    {
+                        // Dead token — purge so we stop sending to it.
+                        // Removing it is progress, so it does not count
+                        // against the batch.
+                        Console.WriteLine(
+                            $"info: AdhocReminderJob - soft-deleting dead device token " +
+                            $"{deviceToken.Id} (worker {deviceToken.WorkerId}, {errorCode})");
+                        await deviceToken.Delete(db);
+                    }
+                    else
+                    {
+                        transientFailures++;
+                    }
+                }
+            }
+
+            if (transientFailures > 0)
+            {
+                // Leave the marker unset: the whole task+kind retries next
+                // hour (healthy tokens may see a duplicate — acceptable).
+                Console.WriteLine(
+                    $"warn: AdhocReminderJob - {transientFailures} transient send failure(s) " +
+                    $"for task {task.Id}; marker left unset for retry next hour");
+                return;
+            }
+        }
+
+        // Marker is written after a clean batch — and also when there was
+        // nobody to notify, so a tokenless task does not re-evaluate every
+        // hour and a device registered later the same day does not receive a
+        // stale reminder.
+        if (isDeadlineReminder)
+        {
+            task.LastDeadlineReminderSentAt = now;
+        }
+        else
+        {
+            task.LastVisibleReminderSentAt = now;
+        }
+
+        await task.Update(db);
+        Console.WriteLine(
+            $"info: AdhocReminderJob - sent {(isDeadlineReminder ? "deadline" : "visible")} " +
+            $"reminder for task {task.Id} to {tokens.Count} device(s)");
+    }
+
+    private static void EnsureFirebaseApp(string serviceAccountJson)
+    {
+        if (FirebaseApp.DefaultInstance != null)
+        {
+            return;
+        }
+
+        lock (FirebaseInitLock)
+        {
+            if (FirebaseApp.DefaultInstance != null)
+            {
+                return;
+            }
+
+            FirebaseApp.Create(new AppOptions
+            {
+                // CredentialFactory is the non-obsolete replacement for
+                // GoogleCredential.FromJson; pinning the generic to
+                // ServiceAccountCredential also fails fast (into the job's
+                // try/catch + Sentry) if the configured JSON is not a
+                // service-account key.
+                Credential = CredentialFactory
+                    .FromJson<ServiceAccountCredential>(serviceAccountJson)
+                    .ToGoogleCredential()
+            });
+        }
+    }
+}

--- a/ServiceBackendConfigurationPlugin/Scheduler/Jobs/AdhocReminderJob.cs
+++ b/ServiceBackendConfigurationPlugin/Scheduler/Jobs/AdhocReminderJob.cs
@@ -54,11 +54,14 @@ namespace ServiceBackendConfigurationPlugin.Scheduler.Jobs;
 /// <c>ExecutionRule == 1</c> (everyone). FCM tokens come from
 /// <c>DeviceTokens</c> (WorkflowState == Created).
 ///
-/// Idempotency: the task's <c>Last*ReminderSentAt</c> marker is written only
-/// AFTER a send batch with no transient failures; a transient failure leaves
-/// the marker unset so the whole task+kind retries next hour. Per-token
-/// permanent failures (UNREGISTERED / INVALID_ARGUMENT) soft-delete that
-/// DeviceToken row and do not block the marker.
+/// Idempotency: the task's <c>Last*ReminderSentAt</c> marker is written per
+/// <see cref="AdhocReminderEvaluator.ShouldWriteMarker"/> — only after a send
+/// attempt with no transient failures, and (for one-shot reminders) only when
+/// at least one device was actually delivered to; a one-shot reminder with
+/// zero live tokens retries hourly until a token exists. Transient failures
+/// always leave the marker unset for retry next hour. Per-token permanent
+/// failures (UNREGISTERED / INVALID_ARGUMENT) soft-delete that DeviceToken
+/// row and do not by themselves block the marker.
 ///
 /// Firebase credentials (service-account JSON) load from the
 /// <c>BackendConfigurationSettings:AdhocFirebaseServiceAccountJson</c>
@@ -214,6 +217,9 @@ public class AdhocReminderJob : IJob
                 .Where(x => workerIds.Contains(x.WorkerId))
                 .ToListAsync();
 
+        var deliveredCount = 0;
+        var transientFailures = 0;
+
         if (tokens.Count > 0)
         {
             var title = string.IsNullOrWhiteSpace(task.Title) ? "Opgave" : task.Title;
@@ -252,7 +258,6 @@ public class AdhocReminderJob : IJob
                 }
             }).ToList();
 
-            var transientFailures = 0;
             for (var offset = 0; offset < messages.Count; offset += FcmBatchLimit)
             {
                 var chunk = messages.Skip(offset).Take(FcmBatchLimit).ToList();
@@ -263,6 +268,7 @@ public class AdhocReminderJob : IJob
                     var response = batch.Responses[i];
                     if (response.IsSuccess)
                     {
+                        deliveredCount++;
                         continue;
                     }
 
@@ -284,22 +290,34 @@ public class AdhocReminderJob : IJob
                     }
                 }
             }
-
-            if (transientFailures > 0)
-            {
-                // Leave the marker unset: the whole task+kind retries next
-                // hour (healthy tokens may see a duplicate — acceptable).
-                Console.WriteLine(
-                    $"warn: AdhocReminderJob - {transientFailures} transient send failure(s) " +
-                    $"for task {task.Id}; marker left unset for retry next hour");
-                return;
-            }
         }
 
-        // Marker is written after a clean batch — and also when there was
-        // nobody to notify, so a tokenless task does not re-evaluate every
-        // hour and a device registered later the same day does not receive a
-        // stale reminder.
+        var kind = isDeadlineReminder ? "deadline" : "visible";
+
+        if (transientFailures > 0)
+        {
+            // Leave the marker unset: the whole task+kind retries next
+            // hour (healthy tokens may see a duplicate — acceptable).
+            Console.WriteLine(
+                $"warn: AdhocReminderJob - {transientFailures} transient send failure(s) " +
+                $"for {kind} reminder on task {task.Id}; marker left unset for retry next hour");
+            return;
+        }
+
+        if (!AdhocReminderEvaluator.ShouldWriteMarker(
+                isDeadlineReminder, task.DeadlineReminderRepeat, deliveredCount, transientFailures))
+        {
+            // One-shot reminder with nothing delivered (no registered
+            // tokens, or every token was dead and just got purged). Its due
+            // instant never recurs, so writing the marker would silently
+            // lose the only delivery attempt — leave it unset and retry
+            // hourly until a live token exists or the task completes.
+            Console.WriteLine(
+                $"warn: AdhocReminderJob - 0 live devices for one-shot {kind} reminder " +
+                $"on task {task.Id}; marker left unset - will retry next tick");
+            return;
+        }
+
         if (isDeadlineReminder)
         {
             task.LastDeadlineReminderSentAt = now;
@@ -310,9 +328,21 @@ public class AdhocReminderJob : IJob
         }
 
         await task.Update(db);
-        Console.WriteLine(
-            $"info: AdhocReminderJob - sent {(isDeadlineReminder ? "deadline" : "visible")} " +
-            $"reminder for task {task.Id} to {tokens.Count} device(s)");
+
+        if (deliveredCount > 0)
+        {
+            Console.WriteLine(
+                $"info: AdhocReminderJob - sent {kind} reminder for task {task.Id} " +
+                $"to {deliveredCount} device(s)");
+        }
+        else
+        {
+            // Weekday-repeat with nobody reachable: today's slot is marked
+            // done (NOT delivered) — the reminder self-heals next weekday.
+            Console.WriteLine(
+                $"warn: AdhocReminderJob - 0 recipients for weekday-repeat deadline reminder " +
+                $"on task {task.Id}; today's slot marked done, next attempt next weekday");
+        }
     }
 
     private static void EnsureFirebaseApp(string serviceAccountJson)

--- a/ServiceBackendConfigurationPlugin/ServiceBackendConfigurationPlugin.csproj
+++ b/ServiceBackendConfigurationPlugin/ServiceBackendConfigurationPlugin.csproj
@@ -13,12 +13,13 @@
   <ItemGroup>
     <PackageReference Include="ChemicalsBase" Version="10.0.15" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
+    <PackageReference Include="FirebaseAdmin" Version="3.6.0" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="14.2.1.1" />
     <PackageReference Include="HtmlToOpenXml.dll" Version="3.4.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.10" />
     <PackageReference Include="Microting.eForm" Version="10.0.36" />
     <PackageReference Include="Microting.EformAngularFrontendBase" Version="10.0.36" />
-    <PackageReference Include="Microting.EformBackendConfigurationBase" Version="10.0.45" />
+    <PackageReference Include="Microting.EformBackendConfigurationBase" Version="10.0.47" />
     <PackageReference Include="Microting.eFormCaseTemplateBase" Version="10.0.34" />
     <PackageReference Include="Microting.ItemsPlanningBase" Version="10.0.36" />
     <PackageReference Include="Microting.WindowsService.BasePn" Version="2.0.0" />

--- a/ServiceBackendConfigurationPlugin/ServiceBackendConfigurationPlugin.csproj
+++ b/ServiceBackendConfigurationPlugin/ServiceBackendConfigurationPlugin.csproj
@@ -14,6 +14,13 @@
     <PackageReference Include="ChemicalsBase" Version="10.0.15" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
     <PackageReference Include="FirebaseAdmin" Version="3.6.0" />
+    <!-- Pin the Google.Apis stack to >= the version shipped by ServiceTimePlanningPlugin
+         (Google.Apis.Sheets.v4 1.75.0.x). All service plugins share one load context in
+         MicrotingService, the first-loaded copy of a simple name wins, and this plugin
+         loads first - shipping a lower version breaks TimePlanning's binds (0x80131040). -->
+    <PackageReference Include="Google.Apis" Version="1.75.0" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.75.0" />
+    <PackageReference Include="Google.Apis.Core" Version="1.75.0" />
     <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="14.2.1.1" />
     <PackageReference Include="HtmlToOpenXml.dll" Version="3.4.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.10" />


### PR DESCRIPTION
Final backend piece of the flutter-adhoc reminder-push feature (spec: flutter-adhoc/docs/superpowers/specs/2026-07-23-reminder-push-design.md). Base bumped to 10.0.47, FirebaseAdmin 3.6.0 added.

- AdhocReminderJob (IJob, Windsor, hourly via the existing _scheduleTimer; per-job try/catch + Sentry like the Drive chain — SearchListJob is now also caught instead of escaping the async-void callback).
- Feature-gated: BackendConfigurationSettings:AdhocReminderPushEnabled; credentials from BackendConfigurationSettings:AdhocFirebaseServiceAccountJson (SendGrid-key convention); both unset → safe no-op.
- Pure AdhocReminderEvaluator (23 tests): due = server-local now ≥ date@*ReminderTimeMinutes (default 08:00); weekday-repeat re-fires Mon–Fri until completed; idempotent via the 10.0.47 Last*ReminderSentAt markers.
- FCM: SendEachAsync chunked at 500, data.taskId (mobile router contract), high_importance_channel, dead tokens (Unregistered/InvalidArgument) soft-deleted.
- Review round: 1 Important (one-shot marker consumed on zero deliveries — token-less worker would silently lose the only attempt forever) → fixed via pure ShouldWriteMarker policy (one-shot retries hourly until a live token delivers; weekday-repeat self-heals; transient failures always retry); re-review: confirmed-fixed, regression test proven non-vacuous.

Activation (ops): insert the two PluginConfigurationValues rows + restart service (migration applies on start); devices register tokens via Settings.RegisterPushToken (plugin PR #1075).

🤖 Generated with [Claude Code](https://claude.com/claude-code)